### PR TITLE
JEQB #174: Generate psk from local random

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ python-dotenv~=0.21.0
 requests~=2.28.1
 Flask~=2.2.2
 pytest~=7.2.0
+Crypto~=1.4.1

--- a/runner/qrng.py
+++ b/runner/qrng.py
@@ -1,10 +1,18 @@
 import requests
+import logging
 
+from Crypto import Random
 from config import config
 
 
 def get_psk():
     url = f"https://qrng.qbck.io/{config['qrng_api_key']}/qbck/block/hex?size=1&length=32"
-    data = requests.get(url)
-    data = data.json()
-    return data['data']['result'][0]
+    try:
+        response = requests.get(url)
+        response.raise_for_status()
+    except (requests.exceptions.RequestException, requests.exceptions.HTTPError):
+        logging.warning("Failed to get key from QRNG: Proceeding to fallback random psk...")
+        return Random.get_random_bytes(32).hex()
+    else:
+        data = response.json()
+        return data['data']['result'][0]


### PR DESCRIPTION
## Description

This PR provides a random psk generation when the qrng way fails.

## Manual checks

- [X] Calling `/psk` POST endpoint

## Resources

- example endpoint logs
![image](https://user-images.githubusercontent.com/44748271/207543234-ab153fb8-20cc-40d8-9686-58a861f529c3.png)

## Known issues

None

## Linked PRs

None